### PR TITLE
Proposal syntax for components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,9 @@
     "key-spacing": 0,
     "no-console": 0,
     "no-multi-spaces": 0,
-    "react/no-did-mount-set-state": 0
+    "no-use-before-define": 0,
+    "react/no-did-mount-set-state": 0,
+    "react/prop-types": 0
   },
   "globals": {
     "webtaskWidget": true,

--- a/src/Repos/index.js
+++ b/src/Repos/index.js
@@ -1,21 +1,15 @@
-import { map } from 'lodash';
+import { assign } from 'lodash';
 
-export default (React) => {
-  const Repos = (props) => {
-    const repos = map(props.repos, (repo, idx) => (
-      <ul key={idx}>{repo.name}</ul>
-    ));
+export default (React) => (props) => {
+  const renderRepos = (repos) => repos.map((repo, idx) => (
+    <ul key={idx}>{repo.name}</ul>
+  ));
 
-    return (
-      <ul>
-        { repos }
-      </ul>
-    );
-  };
+  const { repos } = defaults(props);
 
-  Repos.propTypes = {
-    repos: React.PropTypes.array
-  };
-
-  return Repos;
+  return <ul>{renderRepos(repos)}</ul>;
 };
+
+const defaults = (props) => assign({}, props, {
+  repos: props.repos || []
+});


### PR DESCRIPTION
## Proposals
- Remove `propTypes` in favor of a `defaults` function (https://www.reddit.com/r/reactjs/comments/44yqge/fyi_proptypes_are_on_their_way_out/)
- Remove one level of indentation by doing `export default (React) => (props) => {`
